### PR TITLE
Change to using mingw64 for Windows builds

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -1,7 +1,7 @@
 target  ?= romjudge
 objects := $(patsubst %.c,%.o,$(wildcard *.c))
 CFLAGS  += -Wall -Og -ggdb -std=c99
-CC      := i686-w64-mingw32-gcc
+CC      := i686-w64-mingw64-gcc
 
 .PHONY: all
 all:	$(target)


### PR DESCRIPTION
We are already on a 64-bit OS (based on the 'i686-w64' in the makefile), so we should take advantage of the faster compile times. I also tested using Clang, which makes compile times even faster than mingw64, and produces a slightly smaller executable, but for compatibility and reliability I guess we'll stick to GCC for now.